### PR TITLE
[Phase 8.5] E2E Testing Infrastructure (Maestro)

### DIFF
--- a/maestro/README.md
+++ b/maestro/README.md
@@ -29,10 +29,10 @@ maestro record -e TEST_PASSWORD=<password> flows/auth/login.yaml
 
 ## Environment Variables
 
-| Variable | Default | Description |
-|---|---|---|
-| `TEST_EMAIL` | `test@example.com` | Set in `config.yaml`, override with `-e` |
-| `TEST_PASSWORD` | _(none)_ | **Required** — pass via CLI `-e TEST_PASSWORD=xxx` |
+| Variable        | Default            | Description                                        |
+| --------------- | ------------------ | -------------------------------------------------- |
+| `TEST_EMAIL`    | `test@example.com` | Set in `config.yaml`, override with `-e`           |
+| `TEST_PASSWORD` | _(none)_           | **Required** — pass via CLI `-e TEST_PASSWORD=xxx` |
 
 ## Test Structure
 

--- a/maestro/flows/smoke/app-launches.yaml
+++ b/maestro/flows/smoke/app-launches.yaml
@@ -7,5 +7,5 @@ appId: app.familycarecircle.fcc
     clearState: true
 
 - assertVisible:
-    text: "Email Address"
+    text: 'Email Address'
     timeout: 15000


### PR DESCRIPTION
## Summary
Lightweight E2E testing setup with Maestro for validation before EAS workflows.

## Added
- `maestro/flows/smoke/app-launches.yaml` — minimal smoke test (no credentials needed)
- Updated `maestro/README.md` with actual file structure and usage instructions

## Usage
```bash
# Install Maestro
curl -Ls "https://get.maestro.mobile.dev" | bash

# Quick smoke test
maestro test maestro/flows/smoke/app-launches.yaml

# Full login test
maestro test -e TEST_PASSWORD=<password> maestro/flows/auth/login.yaml
```

## Pre-existing (from earlier work)
- `config.yaml` — app ID, env var defaults
- `flows/auth/login.yaml` — login flow
- `flows/smoke/happy-path.yaml` — login + navigate
- `shared/login.yaml` — reusable sub-flow

Closes #124